### PR TITLE
Accept a string argument as a folder root

### DIFF
--- a/semi-static.js
+++ b/semi-static.js
@@ -6,6 +6,7 @@ var url = require('url'),
 
 module.exports = function (conf) {
     var config = conf || {};
+    if (!_.isObject(config)) config = {folderPath: config + ''}
     _.defaults(config, {
         folderPath: path.dirname(require.main.filename) + '/views/static',
         fileExt: 'jade',


### PR DESCRIPTION
Most Express utilities like this do that. Also, it's easier to type `semiStatic('path')` than `semiStatic({folderPath: 'path'})`. (Programmer laziness... :wink:)
