### PR TITLE
Refactor 'jade' to 'pug'

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "express": "^4.13.3",
-    "jade": "^1.11.0",
+    "pug": "^1.11.0",
     "jshint": "^2.8.0"
   },
   "license": "MIT",

--- a/semi-static.js
+++ b/semi-static.js
@@ -12,7 +12,7 @@ function defaults(config) {
         ret.folderPath = path.dirname(require.main.filename) + "/views/static";
     }
 
-    ret.fileExt = config.fileExt != null ? config.fileExt : "jade";
+    ret.fileExt = config.fileExt != null ? config.fileExt : "pug";
     ret.root = config.root != null ? config.root : "/";
     ret.passReq = !!config.passReq;
     ret.context = config.context;


### PR DESCRIPTION
With the update in ExpressJS to use Pug over Jade, refactor this to accommodate the new default.