### PR TITLE
Fix support for parameters on the request URL

### DIFF
--- a/semi-static.js
+++ b/semi-static.js
@@ -56,9 +56,9 @@ module.exports = function (config) {
         var file, url;
 
         if (config.root && req.url.indexOf(config.root) === 0) {
-            url = req.url.slice(config.root.length);
+            url = reqUrl.slice(config.root.length);
         } else {
-            url = req.url;
+            url = reqUrl;
         }
 
         if (reqUrl === config.root || reqUrl === (config.root + "/")) {


### PR DESCRIPTION
In current implementation, the URL is cleaned on line 55, but then that variable is not used for the file. This results in an exception on line 74. i.e. Error: Failed to lookup view "views/test?param=test&param2=test.handlebars"